### PR TITLE
Version updates for Carbon-transport and Carbon-messaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -974,8 +974,8 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <carbon.transport.version>4.4.18</carbon.transport.version>
-        <carbon.messaging.version>2.3.5</carbon.messaging.version>
+        <carbon.transport.version>4.4.20</carbon.transport.version>
+        <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.0.0</carbon.config.version>
         <carbon.securevault.version>5.0.4</carbon.securevault.version>


### PR DESCRIPTION
This PR updates the version of carbon-transport to 4.4.20 and carbon-messaging to 2.3.7