### PR TITLE
Update the transport version to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -974,7 +974,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <carbon.transport.version>4.4.22</carbon.transport.version>
+        <carbon.transport.version>5.0.0</carbon.transport.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.0.0</carbon.config.version>

--- a/pom.xml
+++ b/pom.xml
@@ -974,7 +974,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <carbon.transport.version>5.0.0</carbon.transport.version>
+        <carbon.transport.version>6.0.0</carbon.transport.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.0.0</carbon.config.version>


### PR DESCRIPTION
This PR includes new version update of carbon-transports.

Please merge and release https://github.com/wso2/carbon-transports/pull/345 before merging this PR.