### PR TITLE
Add h2 jdbc driver dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -643,6 +643,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.ballerinalang</groupId>
                 <artifactId>gson-fragment</artifactId>
                 <version>${ballerina.version}</version>
@@ -950,6 +956,7 @@
         <jcommander.version>1.60</jcommander.version>
         <com.zaxxer.hikaricp.version>2.5.1</com.zaxxer.hikaricp.version>
         <hyperSQL.version>2.3.4</hyperSQL.version>
+        <h2.version>1.3.175</h2.version>
         <gson.version>2.7</gson.version>
         <maven.wagon.ssh.version>2.10</maven.wagon.ssh.version>
         <lambdaj.version>2.3.3</lambdaj.version>


### PR DESCRIPTION
This PR adds the h2 jdbc driver dependency in test scope which is used for XA transaction tests.